### PR TITLE
fix: updated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
           node-version: "16.x"
       - run: npm install
 
-      - name: get-npm-version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
+      - name: get-package-details
+        id: package
+        uses: codex-team/action-nodejs-package-info@v1.1
       - name: install npm packall
         run: npm install npm-pack-all
 
@@ -45,6 +45,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing its ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./datasync-filesystem-sdk-${{ steps.package-version.outputs.current-version }}.tgz
-          asset_name: datasync-filesystem-sdk-${{ steps.package-version.outputs.current-version }}.tgz
+          asset_path: ./${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}.tgz
+          asset_name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}.tgz
           asset_content_type: application/tgz


### PR DESCRIPTION
CS-34703
current package version : 1.0.6

The package version need not be updated as this PR only adds updates to the release workflow. Source code of the plugin remains unchanged